### PR TITLE
handle bug for withdrawal event before distribute call

### DIFF
--- a/src/ethereum.mapping.ts
+++ b/src/ethereum.mapping.ts
@@ -435,7 +435,8 @@ export function handleWithdrawal(event: Withdrawal): void {
       withdrawalEventId,
       account,
       Address.zero().toHexString(),
-      ethAmount
+      ethAmount,
+      false
     );
   }
 
@@ -444,7 +445,8 @@ export function handleWithdrawal(event: Withdrawal): void {
       withdrawalEventId,
       account,
       tokens[i].toHexString(),
-      tokenAmounts[i]
+      tokenAmounts[i],
+      false
     );
   }
 }

--- a/src/polygon.mapping.ts
+++ b/src/polygon.mapping.ts
@@ -277,7 +277,8 @@ export function handleWithdrawal(event: Withdrawal): void {
       withdrawalEventId,
       account,
       Address.zero().toHexString(),
-      ethAmount
+      ethAmount,
+      true
     );
   }
 
@@ -286,7 +287,8 @@ export function handleWithdrawal(event: Withdrawal): void {
       withdrawalEventId,
       account,
       tokens[i].toHexString(),
-      tokenAmounts[i]
+      tokenAmounts[i],
+      true
     );
   }
 }


### PR DESCRIPTION
If a distribute and withdrawal call are grouped together in the same transaction, we're processing the withdrawal event before the distribute call (event handler before call handler). Modifying the withdrawal handler to handle this case for ethereum (it's not an issue on polygon as everything is events there).