### PR TITLE
create user entity for split controllers

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -397,3 +397,14 @@ export function handleTokenWithdrawal(
   tokenWithdrawalEvent.withdrawalEvent = withdrawalEventId;
   tokenWithdrawalEvent.save();
 }
+
+export function createUserIfMissing(
+  accountId: string,
+): void {
+  // only create a User if accountId doesn't point to a Split
+  let splitId = Split.load(accountId);
+  if (!splitId) {
+    let user = new User(accountId);
+    user.save();
+  }
+}


### PR DESCRIPTION
Make sure to create the entity for both the controller of a new split, and the potential controller after an initiate transfer event (I don't think that second one is actually 100% needed, but seems nice to keep things consistent so that all active addresses have a user entity).