### PR TITLE
feat: add contract earnings to all account types

### DIFF
--- a/schema.template.graphql
+++ b/schema.template.graphql
@@ -21,6 +21,7 @@ interface Account {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -67,7 +68,7 @@ type TokenDistribution implements TokenBalance @entity {
 type ContractEarnings @entity {
   id: ID! # ce-${contractId}-${accountId}
   contract: Account!
-  account: User!
+  account: Account!
   internalBalances: [ContractEarningsInternalBalance!]!
     @derivedFrom(field: "contractEarnings")
   withdrawals: [ContractEarningsWithdrawal!]!
@@ -120,6 +121,7 @@ type Split implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -153,6 +155,7 @@ type VestingModule implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -185,6 +188,7 @@ type WaterfallModule implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -216,6 +220,7 @@ type LiquidSplit implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -355,6 +360,7 @@ type Swapper implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!
@@ -408,6 +414,7 @@ type PassThroughWallet implements Account @entity {
   withdrawals: [TokenWithdrawal!]! @derivedFrom(field: "account")
   distributions: [TokenDistribution!]! @derivedFrom(field: "account")
   accountEvents: [AccountEvent!]! @derivedFrom(field: "account")
+  contractEarnings: [ContractEarnings!]! @derivedFrom(field: "account")
   createdBlock: Int!
   latestBlock: Int!
   latestActivity: BigInt!

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -99,32 +99,31 @@ function addInternalBalance(
   // contractEarnings or a separate distributionEarnings entity.
   if (isDistributorIncentive) return
 
-  // Only set contract earnings on users right now. Eventually would like to set them on any account type
-  let user = getUser(accountId)
-  if (user) {
-    let contractEarningsId = saveContractEarnings(splitId, accountId)
-    let contractEarningsInternalBalanceId = createJointId([
-      CONTRACT_EARNINGS_INTERNAL_BALANCE_PREFIX,
-      contractEarningsId,
-      tokenId,
-    ])
-    let contractEarningsInternalBalance = ContractEarningsInternalBalance.load(
+  let contractEarningsId = saveContractEarnings(splitId, accountId).id
+  let contractEarningsInternalBalanceId = createJointId([
+    CONTRACT_EARNINGS_INTERNAL_BALANCE_PREFIX,
+    contractEarningsId,
+    tokenId,
+  ])
+  let contractEarningsInternalBalance = ContractEarningsInternalBalance.load(
+    contractEarningsInternalBalanceId,
+  )
+  if (!contractEarningsInternalBalance) {
+    contractEarningsInternalBalance = new ContractEarningsInternalBalance(
       contractEarningsInternalBalanceId,
     )
-    if (!contractEarningsInternalBalance) {
-      contractEarningsInternalBalance = new ContractEarningsInternalBalance(
-        contractEarningsInternalBalanceId,
-      )
-      contractEarningsInternalBalance.contractEarnings = contractEarningsId
-      contractEarningsInternalBalance.token = tokenId
-      contractEarningsInternalBalance.amount = ZERO
-    }
-    contractEarningsInternalBalance.amount += amount
-    contractEarningsInternalBalance.save()
+    contractEarningsInternalBalance.contractEarnings = contractEarningsId
+    contractEarningsInternalBalance.token = tokenId
+    contractEarningsInternalBalance.amount = ZERO
   }
+  contractEarningsInternalBalance.amount += amount
+  contractEarningsInternalBalance.save()
 }
 
-function saveContractEarnings(contractId: string, accountId: string): string {
+function saveContractEarnings(
+  contractId: string,
+  accountId: string,
+): ContractEarnings {
   let contractEarningsId = createJointId([
     CONTRACT_EARNINGS_PREFIX,
     contractId,
@@ -138,7 +137,7 @@ function saveContractEarnings(contractId: string, accountId: string): string {
     contractEarnings.save()
   }
 
-  return contractEarningsId
+  return contractEarnings
 }
 
 export function saveSetSplitEvent(
@@ -555,72 +554,66 @@ export function updateWithdrawalAmount(
   tokenWithdrawal.amount += amount
   tokenWithdrawal.save()
 
-  // If contractId == accountId this is a split distribution, can ignore. It's a weird edge case,
-  // really shouldn't be captured in withdrawn amount but need to handle for legacy.
-  if (contractId != accountId) {
-    // Ideally can set contract earnings for any account type eventually. For now only setting them on users
-    let account = getUser(accountId)
-    if (!account) return
-
-    if (contractId) {
-      // Funds were pushed directly to the recipient, did not go through split main
-      let contractEarningsId = saveContractEarnings(contractId, accountId)
-      let contractEarningsWithdrawalId = createJointId([
-        CONTRACT_EARINGS_WITHDRAWAL_PREFIX,
-        contractEarningsId,
-        tokenId,
-      ])
-      let contractEarningsWithdrawal = ContractEarningsWithdrawal.load(
+  if (contractId && contractId != accountId) {
+    // Funds were pushed directly to the recipient, did not go through split main
+    let contractEarningsId = saveContractEarnings(contractId, accountId).id
+    let contractEarningsWithdrawalId = createJointId([
+      CONTRACT_EARINGS_WITHDRAWAL_PREFIX,
+      contractEarningsId,
+      tokenId,
+    ])
+    let contractEarningsWithdrawal = ContractEarningsWithdrawal.load(
+      contractEarningsWithdrawalId,
+    )
+    if (!contractEarningsWithdrawal) {
+      contractEarningsWithdrawal = new ContractEarningsWithdrawal(
         contractEarningsWithdrawalId,
       )
-      if (!contractEarningsWithdrawal) {
-        contractEarningsWithdrawal = new ContractEarningsWithdrawal(
-          contractEarningsWithdrawalId,
-        )
-        contractEarningsWithdrawal.contractEarnings = contractEarningsId
-        contractEarningsWithdrawal.token = tokenId
-        contractEarningsWithdrawal.amount = ZERO
-      }
-      contractEarningsWithdrawal.amount += amount
-      contractEarningsWithdrawal.save()
-    } else {
-      // It's a split main withdrawal, move contract earnings internal balances over to contract earnings withdrawals
-      let contractEarningsArray = account.contractEarnings.load()
-      for (let i = 0; i < contractEarningsArray.length; i++) {
-        let contractEarnings = contractEarningsArray[i]
-        let contractEarningsInternalBalanceId = createJointId([
-          CONTRACT_EARNINGS_INTERNAL_BALANCE_PREFIX,
-          contractEarnings.id,
-          tokenId,
-        ])
-        let contractEarningsInternalBalance = ContractEarningsInternalBalance.load(
-          contractEarningsInternalBalanceId,
-        )
-        if (contractEarningsInternalBalance) {
-          if (contractEarningsInternalBalance.amount > ZERO) {
-            let contractEarningsWithdrawalId = createJointId([
-              CONTRACT_EARINGS_WITHDRAWAL_PREFIX,
-              contractEarnings.id,
-              tokenId,
-            ])
-            let contractEarningsWithdrawal = ContractEarningsWithdrawal.load(
+      contractEarningsWithdrawal.contractEarnings = contractEarningsId
+      contractEarningsWithdrawal.token = tokenId
+      contractEarningsWithdrawal.amount = ZERO
+    }
+    contractEarningsWithdrawal.amount += amount
+    contractEarningsWithdrawal.save()
+  } else if (contractId == accountId || !contractId) {
+    // contractId == accountId => split distribution
+    // !contractId => split main withdrawal
+    // Move contract earnings internal balances over to contract earnings withdrawals
+    let contractEarningsArray = getContractEarnings(accountId)
+    for (let i = 0; i < contractEarningsArray.length; i++) {
+      let contractEarnings = contractEarningsArray[i]
+      let contractEarningsInternalBalanceId = createJointId([
+        CONTRACT_EARNINGS_INTERNAL_BALANCE_PREFIX,
+        contractEarnings.id,
+        tokenId,
+      ])
+      let contractEarningsInternalBalance = ContractEarningsInternalBalance.load(
+        contractEarningsInternalBalanceId,
+      )
+      if (contractEarningsInternalBalance) {
+        if (contractEarningsInternalBalance.amount > ZERO) {
+          let contractEarningsWithdrawalId = createJointId([
+            CONTRACT_EARINGS_WITHDRAWAL_PREFIX,
+            contractEarnings.id,
+            tokenId,
+          ])
+          let contractEarningsWithdrawal = ContractEarningsWithdrawal.load(
+            contractEarningsWithdrawalId,
+          )
+          if (!contractEarningsWithdrawal) {
+            contractEarningsWithdrawal = new ContractEarningsWithdrawal(
               contractEarningsWithdrawalId,
             )
-            if (!contractEarningsWithdrawal) {
-              contractEarningsWithdrawal = new ContractEarningsWithdrawal(
-                contractEarningsWithdrawalId,
-              )
-              contractEarningsWithdrawal.contractEarnings = contractEarnings.id
-              contractEarningsWithdrawal.token = tokenId
-              contractEarningsWithdrawal.amount = ZERO
-            }
-            contractEarningsWithdrawal.amount +=
-              contractEarningsInternalBalance.amount
-            contractEarningsWithdrawal.save()
-
-            contractEarningsInternalBalance.amount = ZERO
-            contractEarningsInternalBalance.save()
+            contractEarningsWithdrawal.contractEarnings = contractEarnings.id
+            contractEarningsWithdrawal.token = tokenId
+            contractEarningsWithdrawal.amount = ZERO
           }
+          contractEarningsWithdrawal.amount +=
+            contractEarningsInternalBalance.amount
+          contractEarningsWithdrawal.save()
+
+          contractEarningsInternalBalance.amount = ZERO
+          contractEarningsInternalBalance.save()
         }
       }
     }
@@ -686,6 +679,31 @@ export function createUserIfMissing(
   user.latestBlock = blockNumber
   user.latestActivity = timestamp
   user.save()
+}
+
+function getContractEarnings(accountId: string): ContractEarnings[] {
+  const user = getUser(accountId)
+  if (user) return user.contractEarnings.load()
+
+  const split = getSplit(accountId)
+  if (split) return split.contractEarnings.load()
+
+  const waterfall = getWaterfallModule(accountId)
+  if (waterfall) return waterfall.contractEarnings.load()
+
+  const vesting = getVestingModule(accountId)
+  if (vesting) return vesting.contractEarnings.load()
+
+  const liquidSplit = getLiquidSplit(accountId)
+  if (liquidSplit) return liquidSplit.contractEarnings.load()
+
+  const swapper = getSwapper(accountId)
+  if (swapper) return swapper.contractEarnings.load()
+
+  const passThroughWallet = getPassThroughWallet(accountId)
+  if (passThroughWallet) return passThroughWallet.contractEarnings.load()
+
+  throw new Error('Contract earnings must exist')
 }
 
 export function getSplit(splitId: string): Split | null {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -685,28 +685,31 @@ function getContractEarnings(accountId: string): ContractEarnings[] {
   const user = getUser(accountId)
   if (user) return user.contractEarnings.load()
 
-  const split = getSplit(accountId)
+  const split = getSplit(accountId, false)
   if (split) return split.contractEarnings.load()
 
-  const waterfall = getWaterfallModule(accountId)
+  const waterfall = getWaterfallModule(accountId, false)
   if (waterfall) return waterfall.contractEarnings.load()
 
-  const vesting = getVestingModule(accountId)
+  const vesting = getVestingModule(accountId, false)
   if (vesting) return vesting.contractEarnings.load()
 
-  const liquidSplit = getLiquidSplit(accountId)
+  const liquidSplit = getLiquidSplit(accountId, false)
   if (liquidSplit) return liquidSplit.contractEarnings.load()
 
-  const swapper = getSwapper(accountId)
+  const swapper = getSwapper(accountId, false)
   if (swapper) return swapper.contractEarnings.load()
 
-  const passThroughWallet = getPassThroughWallet(accountId)
+  const passThroughWallet = getPassThroughWallet(accountId, false)
   if (passThroughWallet) return passThroughWallet.contractEarnings.load()
 
   throw new Error('Contract earnings must exist')
 }
 
-export function getSplit(splitId: string): Split | null {
+export function getSplit(
+  splitId: string,
+  required: boolean = true,
+): Split | null {
   let split = Split.load(splitId)
   if (!split) {
     let splitUser = User.load(splitId)
@@ -717,7 +720,7 @@ export function getSplit(splitId: string): Split | null {
       ])
       return null
     }
-    throw new Error('Split must exist')
+    if (required) throw new Error('Split must exist')
   }
 
   return split
@@ -725,6 +728,7 @@ export function getSplit(splitId: string): Split | null {
 
 export function getWaterfallModule(
   waterfallModuleId: string,
+  required: boolean = true,
 ): WaterfallModule | null {
   let waterfall = WaterfallModule.load(waterfallModuleId)
   if (!waterfall) {
@@ -737,7 +741,7 @@ export function getWaterfallModule(
       )
       return null
     }
-    throw new Error('Waterfall must exist')
+    if (required) throw new Error('Waterfall must exist')
   }
 
   return waterfall
@@ -745,6 +749,7 @@ export function getWaterfallModule(
 
 export function getVestingModule(
   vestingModuleId: string,
+  required: boolean = true,
 ): VestingModule | null {
   let vesting = VestingModule.load(vestingModuleId)
   if (!vesting) {
@@ -756,13 +761,16 @@ export function getVestingModule(
       ])
       return null
     }
-    throw new Error('Vesting must exist')
+    if (required) throw new Error('Vesting must exist')
   }
 
   return vesting
 }
 
-export function getLiquidSplit(liquidSplitId: string): LiquidSplit | null {
+export function getLiquidSplit(
+  liquidSplitId: string,
+  required: boolean = true,
+): LiquidSplit | null {
   let liquidSplit = LiquidSplit.load(liquidSplitId)
   if (!liquidSplit) {
     let liquidSplitUser = User.load(liquidSplitId)
@@ -774,14 +782,16 @@ export function getLiquidSplit(liquidSplitId: string): LiquidSplit | null {
       )
       return null
     }
-
-    throw new Error('Liquid split must exist')
+    if (required) throw new Error('Liquid split must exist')
   }
 
   return liquidSplit
 }
 
-export function getSwapper(swapperId: string): Swapper | null {
+export function getSwapper(
+  swapperId: string,
+  required: boolean = true,
+): Swapper | null {
   let swapper = Swapper.load(swapperId)
   if (!swapper) {
     let swapperUser = User.load(swapperId)
@@ -792,7 +802,7 @@ export function getSwapper(swapperId: string): Swapper | null {
       ])
       return null
     }
-    throw new Error('Swapper must exist')
+    if (required) throw new Error('Swapper must exist')
   }
 
   return swapper
@@ -800,6 +810,7 @@ export function getSwapper(swapperId: string): Swapper | null {
 
 export function getPassThroughWallet(
   passThroughWalletId: string,
+  required: boolean = true,
 ): PassThroughWallet | null {
   let passThroughWallet = PassThroughWallet.load(passThroughWalletId)
   if (!passThroughWallet) {
@@ -812,7 +823,7 @@ export function getPassThroughWallet(
       )
       return null
     }
-    throw new Error('Pass through wallet must exist')
+    if (required) throw new Error('Pass through wallet must exist')
   }
 
   return passThroughWallet

--- a/src/pass-through-wallet.mapping.ts
+++ b/src/pass-through-wallet.mapping.ts
@@ -670,17 +670,12 @@ function updateSwapBalance(
   swapBalanceOutput.amount += outputAmount
   swapBalanceOutput.save()
 
-  // Only need to update withdrawn for users. For all modules, swapped funds
-  // will show up in their active balances.
-  let user = User.load(recipient)
-  if (user) {
-    updateWithdrawalAmount(
-      passThroughWalletId,
-      recipient,
-      outputTokenId,
-      outputAmount,
-    )
-  }
+  updateWithdrawalAmount(
+    passThroughWalletId,
+    recipient,
+    outputTokenId,
+    outputAmount,
+  )
 
   // Save events
   let ownerSwapDiversifierFundsEventId = createJointId([

--- a/src/swapper.mapping.ts
+++ b/src/swapper.mapping.ts
@@ -773,12 +773,7 @@ function updateSwapBalance(
 
   updateDistributionAmount(swapperId, inputTokenId, inputAmount)
 
-  // Only need to update withdrawn for users. For all modules, swapped funds
-  // will show up in their active balances.
-  let user = User.load(beneficiary)
-  if (user) {
-    updateWithdrawalAmount(swapperId, beneficiary, outputTokenId, outputAmount)
-  }
+  updateWithdrawalAmount(swapperId, beneficiary, outputTokenId, outputAmount)
 
   // Save events
   let swapFundsEventId = createJointId([

--- a/src/waterfall.mapping.ts
+++ b/src/waterfall.mapping.ts
@@ -187,7 +187,7 @@ export function handleWaterfallFunds(event: WaterfallFunds): void {
   updateDistributionAmount(
     waterfallModuleId,
     waterfallModule.token,
-    totalPayout
+    totalPayout,
   )
 
   // Save event
@@ -265,12 +265,7 @@ export function handleRecoverNonWaterfallFunds(
   receiveNonWaterfallFundsEvent.recoverNonWaterfallFundsEvent = recoverNonWaterfallFundsEventId
   receiveNonWaterfallFundsEvent.save()
 
-  // Only need to update withdrawn for users. For all modules, waterfall'd funds
-  // will show up in their active balances.
-  let user = User.load(accountId)
-  if (user) {
-    updateWithdrawalAmount(waterfallModuleId, accountId, tokenId, amount)
-  }
+  updateWithdrawalAmount(waterfallModuleId, accountId, tokenId, amount)
 }
 
 function createWaterfallTranche(
@@ -365,12 +360,7 @@ function saveWaterfallRecipientReceivedFunds(
   amount: BigInt,
   waterfallModuleId: string,
 ): void {
-  // Only need to update withdrawn for users. For all modules, waterfall'd funds
-  // will show up in their active balances.
-  let user = User.load(accountId)
-  if (user) {
-    updateWithdrawalAmount(waterfallModuleId, accountId, tokenId, amount)
-  }
+  updateWithdrawalAmount(waterfallModuleId, accountId, tokenId, amount)
 
   // Save event
   let waterfallFundsEventId = createJointId([


### PR DESCRIPTION
PE-908: https://linear.app/splits/issue/PE-908/add-account-earnings-column-to-split-recipients-list

Makes `ContractEarnings` field available for all `Account`s 