### PR TITLE
Custom liquid split correct percents

### DIFF
--- a/src/liquid-split.mapping.ts
+++ b/src/liquid-split.mapping.ts
@@ -427,8 +427,13 @@ function updateHolderOwnershipNonFactoryLiquidSplit(
   } else {
     // if it's a transfer, just update the from/to ownership
     let fromHolder = getHolder(fromAddressString, liquidSplitId, blockNumber, timestamp)
-    fromHolder.ownership = liquidSplitContract.scaledPercentBalanceOf(fromAddress)
-    fromHolder.save()
+    let fromOwnership = liquidSplitContract.scaledPercentBalanceOf(fromAddress)
+    if (fromOwnership == ZERO) {
+      store.remove('Holder', fromHolder.id)
+    } else {
+      fromHolder.ownership = fromOwnership
+      fromHolder.save()
+    }
   
     let toHolder = getHolder(toAddressString, liquidSplitId, blockNumber, timestamp)
     toHolder.ownership = liquidSplitContract.scaledPercentBalanceOf(toAddress)

--- a/src/liquid-split.mapping.ts
+++ b/src/liquid-split.mapping.ts
@@ -420,7 +420,7 @@ function updateHolderOwnershipNonFactoryLiquidSplit(
       let holder = holders[i]
       // Only update if it's not the from/to address (i.e. we haven't already updated it)
       if (holder.account != fromAddressString && holder.account != toAddressString) {
-        holder.ownership = liquidSplitContract.scaledPercentBalanceOf(Address.fromString(holder.id))
+        holder.ownership = liquidSplitContract.scaledPercentBalanceOf(Address.fromString(holder.account))
         holder.save()
       }
     }

--- a/src/liquid-split.mapping.ts
+++ b/src/liquid-split.mapping.ts
@@ -396,11 +396,11 @@ function updateHolderOwnershipNonFactoryLiquidSplit(
   let toAddressString = toAddress.toHexString()
 
   if (fromAddressString == ZERO_ADDRESS || toAddressString == ZERO_ADDRESS) {
-    let holders = store.loadRelated('LiquidSplit', liquidSplitId, 'holders')
+    let liquidSplit = LiquidSplit.load(liquidSplitId) as LiquidSplit
+    let holders = liquidSplit.holders.load()
     for (let i = 0; i < holders.length; i++) {
-      let holderAddress = Address.fromString(holders[i].getString('account'))
-      let holder = Holder.load(holders[i].getString('id')) as Holder
-      holder.ownership = liquidSplitContract.scaledPercentBalanceOf(holderAddress)
+      let holder = holders[i]
+      holder.ownership = liquidSplitContract.scaledPercentBalanceOf(Address.fromString(holder.id))
       holder.save()
     }
 

--- a/src/liquid-split.mapping.ts
+++ b/src/liquid-split.mapping.ts
@@ -410,8 +410,13 @@ function updateHolderOwnershipNonFactoryLiquidSplit(
   
     if (toAddressString != ZERO_ADDRESS) {
       let toHolder = getHolder(toAddressString, liquidSplitId, blockNumber, timestamp)
-      toHolder.ownership = liquidSplitContract.scaledPercentBalanceOf(toAddress)
-      toHolder.save()
+      let ownership = liquidSplitContract.scaledPercentBalanceOf(toAddress)
+      if (ownership == ZERO) {
+        store.remove('Holder', toHolder.id)
+      } else {
+        toHolder.ownership = ownership
+        toHolder.save()
+      }
     }
 
     let liquidSplit = LiquidSplit.load(liquidSplitId) as LiquidSplit
@@ -436,8 +441,13 @@ function updateHolderOwnershipNonFactoryLiquidSplit(
     }
   
     let toHolder = getHolder(toAddressString, liquidSplitId, blockNumber, timestamp)
-    toHolder.ownership = liquidSplitContract.scaledPercentBalanceOf(toAddress)
-    toHolder.save()
+    let toOwnership = liquidSplitContract.scaledPercentBalanceOf(toAddress)
+    if (toOwnership == ZERO) {
+      store.remove('Holder', toHolder.id)
+    } else {
+      toHolder.ownership = toOwnership
+      toHolder.save()
+    }
   }
 }
 


### PR DESCRIPTION
Custom liquid splits can support mint/burns and have their own custom logic for percentage allocated to each nft holder. Whenever there is a mint or burn we need to loop through all the existing holders and update their ownership percentage as well.